### PR TITLE
Fix add item input fields styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ Country
             <td class="invoice-item__description">
               <input
                 id="invoice-item__description"
-                class="invoice-item__input"
+                class="invoice-item__input invoice-item__input--description editable editable--dark"
                 type="text"
                 placeholder="Item Description"
               />
@@ -124,7 +124,7 @@ Country
             <td class="invoice-item__quantity">
               <input
                 id="invoice-item__quantity"
-                class="invoice-item__input"
+                class="invoice-item__input invoice-item__input--quantity editable editable--dark"
                 type="number"
                 placeholder="1"
                 min="1"
@@ -133,7 +133,7 @@ Country
             <td class="invoice-item__price">
               <input
                 id="invoice-item__price"
-                class="invoice-item__input"
+                class="invoice-item__input invoice-item__input--price editable editable--dark"
                 type="number"
                 placeholder="100.00"
                 min="0.01"

--- a/main.css
+++ b/main.css
@@ -175,10 +175,27 @@ body {
 
 .invoice-item__input {
   background: transparent;
-  border-bottom: 1px dashed var(--dark);
   border: none;
   text-align: center;
   width: 100%;
+}
+
+.invoice-item__input--description {
+  left: -0.1em;
+  position: relative;
+  text-align: left;
+}
+
+.invoice-item__input--quantity {
+  position: relative;
+  right: -0.5em;
+  text-align: center;
+}
+
+.invoice-item__input--price {
+  position: relative;
+  right: -1em;
+  text-align: right;
 }
 
 .invoice-item__description {


### PR DESCRIPTION
Adjust alignment of placeholder text in input fields for adding an item. Placeholders are now aligned with any previously added item text, but only in WebKit/Blink browsers. Alignment in Firefox was OK without these changes. Now, it's a bit off.

See #23