### PR TITLE
Remove placeholder data in invoice summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,10 +43,25 @@ const view = {
   itemPriceEl: document.getElementById('invoice-item__price'),
   formRowEl: document.getElementById('form-row'),
   addItemBtn: document.getElementById('add-item-btn'),
+  subtotalInvoiceAmount: document.getElementById('invoice-summary__subtotal'),
   taxRateInput: document.getElementById('tax-rate-input'),
   taxRateAmount: document.getElementById('invoice-summary__tax-amount'),
   shippingCostInput: document.getElementById('shipping-cost-input'),
   totalInvoiceAmount: document.getElementById('invoice-summary__total-amount'),
+
+  setUpInitialValues() {
+    this.subtotalInvoiceAmount.textContent = utils.formatNumberDisplay(
+      model.invoiceSubtotal
+    );
+    this.taxRateInput.value = utils.formatNumberDisplay(model.invoiceTaxRate);
+    this.taxRateAmount.textContent = utils.formatNumberDisplay(0);
+    this.shippingCostInput.value = utils.formatNumberDisplay(
+      model.invoiceShippingCost
+    );
+    this.totalInvoiceAmount.textContent = utils.formatNumberDisplay(
+      model.invoiceTotal
+    );
+  },
 
   addTableRow(data) {
     const tableRow = document.createElement('tr');
@@ -84,8 +99,7 @@ const view = {
   },
 
   updateSubtotal(amount) {
-    document.getElementById('invoice-summary__subtotal').textContent =
-      utils.formatNumberDisplay(amount);
+    this.subtotalInvoiceAmount.textContent = utils.formatNumberDisplay(amount);
   },
 
   updateTotal(amount) {
@@ -194,6 +208,8 @@ const controller = {
     view.updateTotal(model.invoiceTotal);
   },
 };
+
+view.setUpInitialValues();
 
 view.addItemBtn.addEventListener(
   'click',

--- a/index.html
+++ b/index.html
@@ -101,17 +101,6 @@ Country
           </tr>
         </thead>
         <tbody id="invoice-items__body" class="invoice-items__body">
-          <tr class="invoice-item__row">
-            <td class="invoice-item__description">Item Name</td>
-            <td class="invoice-item__quantity">1</td>
-            <td class="invoice-item__price">100.00</td>
-            <td class="invoice-item__amount">100.00</td>
-            <td class="invoice-item__remove">
-              <button class="invoice-item__button">
-                <i class="fa-regular fa-square-minus"></i>
-              </button>
-            </td>
-          </tr>
           <tr id="form-row">
             <td class="invoice-item__description">
               <input
@@ -158,7 +147,7 @@ Country
           <tr>
             <td class="invoice-summary__description">Subtotal</td>
             <td id="invoice-summary__subtotal" class="invoice-summary__amount">
-              20,100.00
+              0.00
             </td>
           </tr>
           <tr>
@@ -178,7 +167,7 @@ Country
               id="invoice-summary__tax-amount"
               class="invoice-summary__amount"
             >
-              2,010.00
+              0.00
             </td>
           </tr>
           <tr>
@@ -201,7 +190,7 @@ Country
               id="invoice-summary__total-amount"
               class="invoice-summary__amount"
             >
-              22,250.00
+              0.00
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
Removed placeholder amounts in the invoice summary part of the app. All values are set to 0 upon app load.

See #25